### PR TITLE
Fix typo in clamav_ng role

### DIFF
--- a/roles/clamav_ng/tasks/configure.yml
+++ b/roles/clamav_ng/tasks/configure.yml
@@ -170,7 +170,7 @@
     sysctl_set: true
   when:
     - clamav_ng_clamonacc_enabled
-    - (sysctl.stdouu|int < 524288)
+    - (sysctl.stdout|int < 524288)
     - sysctl.rc == 0
 
 - name: Configure | Enable and start the Freshclam service


### PR DESCRIPTION
Fixes a typo in one of the "clamonacc" tasks
- Update `stdouu` -> `stdout`